### PR TITLE
Fix mobile layout alignment

### DIFF
--- a/src/AppFrame.tsx
+++ b/src/AppFrame.tsx
@@ -41,22 +41,20 @@ export function AppFrame() {
       showMobileNavigation={isMobileNavigationActive}
       onNavigationDismiss={handleMobileNavigationToggle}
     >
-      <Layout>
-        <Layout.Section>
-          <Page>
+      <Page fullWidth>
+        <Layout>
+          <Layout.Section>
             <Routes />
-          </Page>
-        </Layout.Section>
-        <Layout.Section secondary>
-          <Page>
+          </Layout.Section>
+          <Layout.Section secondary>
             <TwitterTimelineEmbed
               sourceType="profile"
               screenName="VaxHuntersCan"
               options={{ height: 800 }}
             />
-          </Page>
-        </Layout.Section>
-      </Layout>
+          </Layout.Section>
+        </Layout>
+      </Page>
     </Frame>
   );
 }

--- a/src/components/EligibilityBanner/EligibilityBanner.tsx
+++ b/src/components/EligibilityBanner/EligibilityBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Banner, Layout } from "@shopify/polaris";
+import { Banner } from "@shopify/polaris";
 
 interface Props {
   onDismiss: () => void;
@@ -7,13 +7,11 @@ interface Props {
 
 export function EligibilityBanner(props: Props) {
   return (
-    <Layout.Section>
-      <>
-        <Banner title="Eligibility:" onDismiss={props.onDismiss} status="info">
-          In order to ensure you are eligible to receive your vaccine, please
-          check your appropriate health authority&apos;s vaccination guidelines.
-        </Banner>
-      </>
-    </Layout.Section>
+    <>
+      <Banner title="Eligibility:" onDismiss={props.onDismiss} status="info">
+        In order to ensure you are eligible to receive your vaccine, please
+        check your appropriate health authority&apos;s vaccination guidelines.
+      </Banner>
+    </>
   );
 }

--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { format } from "date-fns-tz";
-import { Card, Banner, TextContainer, Stack, Layout } from "@shopify/polaris";
+import { Card, Banner, TextContainer, Stack } from "@shopify/polaris";
 import { DomainsMajor, LocationMajor } from "@shopify/polaris-icons";
 import Iframe from "react-iframe";
 
@@ -49,39 +49,37 @@ export function PharmacyCard(props: PharmacyProps) {
     />
   );
   return (
-    <Layout.Section>
-      <Card
-        title={props.pharmacyName}
-        sectioned
-        primaryFooterAction={{
-          content: "Visit Website",
-          icon: DomainsMajor,
-          external: true,
-          url: props.website,
-        }}
-        secondaryFooterActions={[
-          {
-            content: "Load Map",
-            icon: LocationMajor,
-            onAction: () => {
-              setShouldShowMap(!shouldShowMap);
-            },
+    <Card
+      title={props.pharmacyName}
+      sectioned
+      primaryFooterAction={{
+        content: "Visit Website",
+        icon: DomainsMajor,
+        external: true,
+        url: props.website,
+      }}
+      secondaryFooterActions={[
+        {
+          content: "Load Map",
+          icon: LocationMajor,
+          onAction: () => {
+            setShouldShowMap(!shouldShowMap);
           },
-        ]}
-      >
-        <TextContainer>
-          <Card.Section fullWidth>{availabilityMarkup()}</Card.Section>
-          <Card.Section title="Store Info">
-            <Card.Subsection>{props.address}</Card.Subsection>
-            <Card.Subsection>
-              <Stack>
-                <Stack.Item>{props.phone}</Stack.Item>
-              </Stack>
-            </Card.Subsection>
-          </Card.Section>
-        </TextContainer>
-        {shouldShowMap ? <Map /> : null}
-      </Card>
-    </Layout.Section>
+        },
+      ]}
+    >
+      <TextContainer>
+        <Card.Section fullWidth>{availabilityMarkup()}</Card.Section>
+        <Card.Section title="Store Info">
+          <Card.Subsection>{props.address}</Card.Subsection>
+          <Card.Subsection>
+            <Stack>
+              <Stack.Item>{props.phone}</Stack.Item>
+            </Stack>
+          </Card.Subsection>
+        </Card.Section>
+      </TextContainer>
+      {shouldShowMap ? <Map /> : null}
+    </Card>
   );
 }

--- a/src/containers/PharmacyList/PharmacyList.test.tsx
+++ b/src/containers/PharmacyList/PharmacyList.test.tsx
@@ -51,20 +51,18 @@ describe("PharmacyList", () => {
     render(<PharmacyList postalCode="k2s 1s9" />);
     const pharmacyList = await screen.findByLabelText(/pharmacy-list/i);
 
-    // pharmacyList.childNodes[0] is the eligibility notice
-
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     /* eslint-disable @typescript-eslint/no-unsafe-call */
+    await within(pharmacyList.childNodes[0]).findByText(
+      /appointments available/i,
+    );
     await within(pharmacyList.childNodes[1]).findByText(
       /appointments available/i,
     );
     await within(pharmacyList.childNodes[2]).findByText(
-      /appointments available/i,
-    );
-    await within(pharmacyList.childNodes[3]).findByText(
       /appointments not available/i,
     );
-    await within(pharmacyList.childNodes[4]).findByText(
+    await within(pharmacyList.childNodes[3]).findByText(
       /appointments not available/i,
     );
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */

--- a/src/containers/PharmacyList/PharmacyList.tsx
+++ b/src/containers/PharmacyList/PharmacyList.tsx
@@ -102,27 +102,28 @@ export function PharmacyList(props: Props) {
     );
 
   return (
-    <section aria-label="pharmacy-list">
+    <>
       {shouldShowBanner ? (
         <EligibilityBanner onDismiss={() => setShouldShowBanner(false)} />
       ) : null}
-
-      {pharmacyList
-        ? pharmacyList.map((pharmacy) => {
-            return (
-              <PharmacyCard
-                key={pharmacy.id}
-                id={pharmacy.id}
-                address={pharmacy.address}
-                booking={pharmacy.booking}
-                lastUpdated={pharmacy.lastUpdated}
-                pharmacyName={pharmacy.pharmacyName}
-                phone={pharmacy.phone}
-                website={pharmacy.website}
-              />
-            );
-          })
-        : null}
-    </section>
+      <section aria-label="pharmacy-list" style={{ marginTop: "2rem" }}>
+        {pharmacyList
+          ? pharmacyList.map((pharmacy) => {
+              return (
+                <PharmacyCard
+                  key={pharmacy.id}
+                  id={pharmacy.id}
+                  address={pharmacy.address}
+                  booking={pharmacy.booking}
+                  lastUpdated={pharmacy.lastUpdated}
+                  pharmacyName={pharmacy.pharmacyName}
+                  phone={pharmacy.phone}
+                  website={pharmacy.website}
+                />
+              );
+            })
+          : null}
+      </section>
+    </>
   );
 }


### PR DESCRIPTION
Fixes an issue where the cards and banner on the /search path are pushed too far to the right on mobile screens. Problem was being caused by nested <Layout.Section>'s

| Before (iPhone X)  | After (iPhone X) |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/48600727/117326616-d5619380-ae5f-11eb-837a-b80f4b7a87c3.png) | ![image](https://user-images.githubusercontent.com/48600727/117326858-0e9a0380-ae60-11eb-8ca7-fb24455ce5aa.png) |

Something to note: Containers and individual Components should not return anything wrapped in `<Layout.Section>` since the AppFrame already wraps the Route's response in a `<Layout.Section>` 