### PR TITLE
run encodeURIComponent on address sent to Google Maps API

### DIFF
--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -104,7 +104,9 @@ export function PharmacyCard(props: PharmacyProps) {
   const Map = () => (
     <Iframe
       // the key is hardcoded for now, but there's no rate limit or usage limit for embedding
-      url={`https://www.google.com/maps/embed/v1/place?q=${props.address}&key=AIzaSyCJF0WPrXAbLIePWWFbS7rRxdCBaY8pjAs`}
+      url={`https://www.google.com/maps/embed/v1/place?q=${encodeURIComponent(
+        props.address,
+      )}&key=AIzaSyCJF0WPrXAbLIePWWFbS7rRxdCBaY8pjAs`}
       width="100%"
       height="350px"
       position="relative"


### PR DESCRIPTION
Run encodeURIComponent on address sent to Google Maps API

Should allow Google Maps to work properly on an address of a Walmart in Vaughan with # in the address that was causing Google Maps to fail, as well as fix security vulnerability which would allow JavaScript to be injected in the address.

Closes #134