### PR TITLE
Reduce spacing between badges on pharmacy card

### DIFF
--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -261,7 +261,7 @@ export function PharmacyCard(props: PharmacyProps) {
     >
       <div data-testid="pharmacy-card">
         <TextContainer>
-          <Stack spacing="tight">{badgeMarkup()}</Stack>
+          <Stack spacing="extraTight">{badgeMarkup()}</Stack>
           <Card.Section fullWidth>{availabilityMarkup()}</Card.Section>
           <Card.Section title={t("details")}>
             <Card.Subsection>{props.address}</Card.Subsection>

--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -261,7 +261,7 @@ export function PharmacyCard(props: PharmacyProps) {
     >
       <div data-testid="pharmacy-card">
         <TextContainer>
-          <Stack>{badgeMarkup()}</Stack>
+          <Stack spacing="tight">{badgeMarkup()}</Stack>
           <Card.Section fullWidth>{availabilityMarkup()}</Card.Section>
           <Card.Section title={t("details")}>
             <Card.Subsection>{props.address}</Card.Subsection>


### PR DESCRIPTION
The spacing between the badges on the pharmacy were way too wide, so I reduced the spacing in-between to allow more content to be above the fold.
[Before](https://user-images.githubusercontent.com/9260542/122491949-e949fa80-cfb2-11eb-8dca-ffedf0220175.png) vs [After](https://user-images.githubusercontent.com/9260542/122496329-9293ef00-cfb9-11eb-96c1-d23b8bb00ea5.png)
