### PR TITLE
Remove section wrapping the banner on pharmacy card

### DIFF
--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -262,7 +262,7 @@ export function PharmacyCard(props: PharmacyProps) {
       <div data-testid="pharmacy-card">
         <TextContainer>
           <Stack>{badgeMarkup()}</Stack>
-          <Card.Section fullWidth>{availabilityMarkup()}</Card.Section>
+          {availabilityMarkup()}
           <Card.Section title={t("details")}>
             <Card.Subsection>{props.address}</Card.Subsection>
             <Card.Subsection>


### PR DESCRIPTION
Section is unnecessary for banner on a card, this should remove the awkward spacing surrounding the availability banner
Reference: [Banner in a card](https://polaris.shopify.com/components/feedback-indicators/banner)

[Before](https://user-images.githubusercontent.com/9260542/122495617-57dd8700-cfb8-11eb-81fe-50f695664f76.png) vs [After](https://user-images.githubusercontent.com/9260542/122495591-4c8a5b80-cfb8-11eb-8ff4-62703820acf6.png)
