### PR TITLE
Tweak pharmacy card layout

### DIFF
--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -261,7 +261,7 @@ export function PharmacyCard(props: PharmacyProps) {
     >
       <div data-testid="pharmacy-card">
         <TextContainer>
-          <Stack>{badgeMarkup()}</Stack>
+          <Stack spacing="extraTight">{badgeMarkup()}</Stack>
           <Card.Section fullWidth>{availabilityMarkup()}</Card.Section>
           <Card.Section title={t("details")}>
             <Card.Subsection>{props.address}</Card.Subsection>

--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -262,7 +262,7 @@ export function PharmacyCard(props: PharmacyProps) {
       <div data-testid="pharmacy-card">
         <TextContainer>
           <Stack spacing="extraTight">{badgeMarkup()}</Stack>
-          <Card.Section fullWidth>{availabilityMarkup()}</Card.Section>
+          {availabilityMarkup()}
           <Card.Section title={t("details")}>
             <Card.Subsection>{props.address}</Card.Subsection>
             <Card.Subsection>
@@ -272,7 +272,7 @@ export function PharmacyCard(props: PharmacyProps) {
             </Card.Subsection>
           </Card.Section>
           {/* {appointmentsAvailableMarkup()} */}
-          <Card.Section fullWidth>{bannerMarkup()}</Card.Section>
+          {bannerMarkup()}
         </TextContainer>
         {shouldShowMap ? <Map /> : null}
       </div>

--- a/src/components/PharmacyCard/PharmacyCard.tsx
+++ b/src/components/PharmacyCard/PharmacyCard.tsx
@@ -7,6 +7,7 @@ import {
   DataTable,
   Button,
   Badge,
+  DescriptionList,
 } from "@shopify/polaris";
 import { DomainsMajor, LocationMajor } from "@shopify/polaris-icons";
 import Iframe from "react-iframe";
@@ -263,14 +264,18 @@ export function PharmacyCard(props: PharmacyProps) {
         <TextContainer>
           <Stack spacing="extraTight">{badgeMarkup()}</Stack>
           {availabilityMarkup()}
-          <Card.Section title={t("details")}>
-            <Card.Subsection>{props.address}</Card.Subsection>
-            <Card.Subsection>
-              <Stack>
-                <Stack.Item>{props.phone}</Stack.Item>
-              </Stack>
-            </Card.Subsection>
-          </Card.Section>
+          <DescriptionList
+            items={[
+              {
+                term: t("address"),
+                description: props.address,
+              },
+              {
+                term: t("phone"),
+                description: props.phone || "-",
+              },
+            ]}
+          />
           {/* {appointmentsAvailableMarkup()} */}
           {bannerMarkup()}
         </TextContainer>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+  "address": "Address",
   "admin": "Admin",
   "anerrorhasoccurred": "An error has occurred",
   "asof": "as of {{date, MMM d, y}}",


### PR DESCRIPTION
- Reduce spacing between badges
- Remove container for banner and reduce spacing
- Format location details into a description list
- Add `address` to localization strings

![image](https://user-images.githubusercontent.com/9260542/122686719-b7b67680-d1e0-11eb-98e3-a069067ebfe5.png)