### PR TITLE
Make the footer link relative to the searched postal code

### DIFF
--- a/src/AppFrame.tsx
+++ b/src/AppFrame.tsx
@@ -1,15 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useCallback, useContext, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
-import {
-  FooterHelp,
-  Frame,
-  Layout,
-  Link,
-  Navigation,
-  Page,
-  TopBar,
-} from "@shopify/polaris";
+import { Frame, Layout, Navigation, Page, TopBar } from "@shopify/polaris";
 import {
   HomeMajor,
   LockMajor,
@@ -259,13 +251,6 @@ export function AppFrame() {
         <Layout>
           <Layout.Section>
             <Routes />
-            <FooterHelp>
-              Get more resources{" "}
-              <Link external url="https://vaccinehunters.ca/diy">
-                on our DIY pages
-              </Link>
-              .
-            </FooterHelp>
           </Layout.Section>
           <Layout.Section secondary>
             <Twitter />

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render } from "../../testUtils";
+import { Footer } from "./Footer";
+
+describe("Footer", () => {
+  test("Should render the default", async () => {
+    const { getByText } = render(<Footer />);
+    expect(getByText(/Get more resources/)).toBeInTheDocument();
+    expect(getByText(/on our DIY pages/)).toHaveAttribute(
+      "href",
+      "https://vaccinehunters.ca/diy"
+    );
+  });
+
+  test.each([
+    [
+      "T0X0X0",
+      /Get more Alberta resources/,
+      "https://vaccinehunters.ca/alberta",
+    ],
+    [
+      "M0X0X0",
+      /Get more Ontario resources/,
+      "https://vaccinehunters.ca/ontario",
+    ],
+  ])(
+    "Should render the appropriate text and link for postal code",
+    async (postalCode, expectedText, expectedLink) => {
+      const { getByText } = render(<Footer postalCode={postalCode} />);
+      expect(getByText(expectedText)).toBeInTheDocument();
+      expect(getByText(/on our DIY pages/)).toHaveAttribute(
+        "href",
+        expectedLink
+      );
+    }
+  );
+});

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -23,6 +23,16 @@ describe("Footer", () => {
       /Get more Ontario resources/,
       "https://vaccinehunters.ca/ontario",
     ],
+    [
+      "X0A0X0",
+      /Get more Nunavut resources/,
+      "https://vaccinehunters.ca/nunavut",
+    ],
+    [
+      "X0X0X0",
+      /Get more Northwest Territories resources/,
+      "https://vaccinehunters.ca/northwestterritories",
+    ],
   ])(
     "Should render the appropriate text and link for postal code",
     async (postalCode, expectedText, expectedLink) => {

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -3,12 +3,12 @@ import { render } from "../../testUtils";
 import { Footer } from "./Footer";
 
 describe("Footer", () => {
-  test("Should render the default", async () => {
+  test("Should render the default", () => {
     const { getByText } = render(<Footer />);
     expect(getByText(/Get more resources/)).toBeInTheDocument();
     expect(getByText(/on our DIY pages/)).toHaveAttribute(
       "href",
-      "https://vaccinehunters.ca/diy"
+      "https://vaccinehunters.ca/diy",
     );
   });
 
@@ -35,13 +35,13 @@ describe("Footer", () => {
     ],
   ])(
     "Should render the appropriate text and link for postal code",
-    async (postalCode, expectedText, expectedLink) => {
+    (postalCode, expectedText, expectedLink) => {
       const { getByText } = render(<Footer postalCode={postalCode} />);
       expect(getByText(expectedText)).toBeInTheDocument();
       expect(getByText(/on our DIY pages/)).toHaveAttribute(
         "href",
-        expectedLink
+        expectedLink,
       );
-    }
+    },
   );
 });

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,81 +7,98 @@ interface LocationData {
   name: string;
 }
 
+/** Given a postal code, fetch the appropriate location in Canada
+ * First letter typically gives the province or territory
+ * Nunavut and Northwest Territories are a notable exception, both starting with 'X'
+ * See: https://en.wikipedia.org/wiki/Postal_codes_in_Canada#Components_of_a_postal_code
+ */
 function getLocation(postalCode: string | undefined): LocationData {
   const rootUrl = "https://vaccinehunters.ca";
-  switch (postalCode?.charAt(0).toUpperCase() ?? "") {
-    case "T":
-      return {
-        url: `${rootUrl}/alberta`,
-        name: "Alberta",
-      };
-    case "V":
-      return {
-        url: `${rootUrl}/britishcolumbia`,
-        name: "British Columbia",
-      };
-    case "R":
-      return {
-        url: `${rootUrl}/manitoba`,
-        name: "Manitoba",
-      };
-    case "E":
-      return {
-        url: `${rootUrl}/newbrunswick`,
-        name: "New Brunswick",
-      };
-    case "A":
-      return {
-        url: `${rootUrl}/newfoundlandandlabrador`,
-        name: "Newfoundland and Labrador",
-      };
-    case "B":
-      return {
-        url: `${rootUrl}/novascotia`,
-        name: "Nova Scotia",
-      };
-    case "X":
-      return {
-        url: `${rootUrl}/nunavut`,
-        name: "Nunavut",
-      };
-    case "K":
-    case "L":
-    case "M":
-    case "N":
-    case "P":
-      return {
-        url: `${rootUrl}/ontario`,
-        name: "Ontario",
-      };
-    case "C":
-      return {
-        url: `${rootUrl}/princeedwardisland`,
-        name: "Prince Edward Island",
-      };
-    case "J":
-    case "G":
-    case "H":
-      return {
-        url: `${rootUrl}/quebec`,
-        name: "Quebec",
-      };
-    case "S":
-      return {
-        url: `${rootUrl}/saskatchewan`,
-        name: "Saskatchewan",
-      };
-    case "Y":
-      return {
-        url: `${rootUrl}/yukon`,
-        name: "Yukon",
-      };
-    default:
-      return {
-        url: `${rootUrl}/diy`,
-        name: "",
-      };
+  const postalDistrict = postalCode?.charAt(0).toUpperCase() ?? "";
+  const forwardSortationArea = postalCode?.slice(0, 3).toUpperCase() ?? "";
+
+  if (postalDistrict === "T") {
+    return {
+      url: `${rootUrl}/alberta`,
+      name: "Alberta",
+    };
   }
+  if (postalDistrict === "V") {
+    return {
+      url: `${rootUrl}/britishcolumbia`,
+      name: "British Columbia",
+    };
+  }
+  if (postalDistrict === "R") {
+    return {
+      url: `${rootUrl}/manitoba`,
+      name: "Manitoba",
+    };
+  }
+  if (postalDistrict === "E") {
+    return {
+      url: `${rootUrl}/newbrunswick`,
+      name: "New Brunswick",
+    };
+  }
+  if (postalDistrict === "A") {
+    return {
+      url: `${rootUrl}/newfoundlandandlabrador`,
+      name: "Newfoundland and Labrador",
+    };
+  }
+  if (postalDistrict === "B") {
+    return {
+      url: `${rootUrl}/novascotia`,
+      name: "Nova Scotia",
+    };
+  }
+  if (["X0A", "X0B", "X0C"].includes(forwardSortationArea)) {
+    return {
+      url: `${rootUrl}/nunavut`,
+      name: "Nunavut",
+    };
+  }
+  if (postalDistrict === "X") {
+    return {
+      url: `${rootUrl}/northwestterritories`,
+      name: "Northwest Territories",
+    };
+  }
+  if (["K", "L", "M", "N"].includes(postalDistrict)) {
+    return {
+      url: `${rootUrl}/ontario`,
+      name: "Ontario",
+    };
+  }
+  if (postalDistrict === "C") {
+    return {
+      url: `${rootUrl}/princeedwardisland`,
+      name: "Prince Edward Island",
+    };
+  }
+  if (["J", "G", "H"].includes(postalDistrict)) {
+    return {
+      url: `${rootUrl}/quebec`,
+      name: "Quebec",
+    };
+  }
+  if (postalDistrict === "S") {
+    return {
+      url: `${rootUrl}/saskatchewan`,
+      name: "Saskatchewan",
+    };
+  }
+  if (postalDistrict === "Y") {
+    return {
+      url: `${rootUrl}/yukon`,
+      name: "Yukon",
+    };
+  }
+  return {
+    url: `${rootUrl}/diy`,
+    name: "",
+  };
 }
 
 interface Props {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from "react";
+import { FooterHelp, Link } from "@shopify/polaris";
+
+interface LocationData {
+  url: string;
+  name: string;
+}
+
+function getLocation(postalCode: string | undefined): LocationData {
+  const rootUrl = "https://vaccinehunters.ca";
+  switch (postalCode?.charAt(0).toUpperCase() ?? "") {
+    case "T":
+      return {
+        url: `${rootUrl}/alberta`,
+        name: "Alberta",
+      };
+    case "V":
+      return {
+        url: `${rootUrl}/britishcolumbia`,
+        name: "British Columbia",
+      };
+    case "R":
+      return {
+        url: `${rootUrl}/manitoba`,
+        name: "Manitoba",
+      };
+    case "E":
+      return {
+        url: `${rootUrl}/newbrunswick`,
+        name: "New Brunswick",
+      };
+    case "A":
+      return {
+        url: `${rootUrl}/newfoundlandandlabrador`,
+        name: "Newfoundland and Labrador",
+      };
+    case "B":
+      return {
+        url: `${rootUrl}/novascotia`,
+        name: "Nova Scotia",
+      };
+    case "X":
+      return {
+        url: `${rootUrl}/nunavut`,
+        name: "Nunavut",
+      };
+    case "K":
+    case "L":
+    case "M":
+    case "N":
+    case "P":
+      return {
+        url: `${rootUrl}/ontario`,
+        name: "Ontario",
+      };
+    case "C":
+      return {
+        url: `${rootUrl}/princeedwardisland`,
+        name: "Prince Edward Island",
+      };
+    case "J":
+    case "G":
+    case "H":
+      return {
+        url: `${rootUrl}/quebec`,
+        name: "Quebec",
+      };
+    case "S":
+      return {
+        url: `${rootUrl}/saskatchewan`,
+        name: "Saskatchewan",
+      };
+    case "Y":
+      return {
+        url: `${rootUrl}/yukon`,
+        name: "Yukon",
+      };
+    default:
+      return {
+        url: `${rootUrl}/diy`,
+        name: "",
+      };
+  }
+}
+
+interface Props {
+  postalCode?: string;
+}
+
+export function Footer({ postalCode }: Props) {
+  const location = getLocation(postalCode);
+  return (
+    <FooterHelp>
+      Get more {location.name} resources{" "}
+      <Link external url={location.url}>
+        on our DIY pages
+      </Link>
+      .
+    </FooterHelp>
+  );
+}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,0 +1,1 @@
+export { Footer } from "./Footer";

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { Home } from "../containers/Home";
+import { Footer } from "../components/Footer";
 
 // eslint-disable-next-line import/no-default-export
 export default function HomeRoute() {
-  return <Home />;
+  return (
+    <>
+      <Home />
+      <Footer />
+    </>
+  );
 }

--- a/src/routes/Search.tsx
+++ b/src/routes/Search.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { PharmacyList } from "../containers/PharmacyList";
+import { Footer } from "../components/Footer";
 
 interface SearchRouteParam {
   postalCode: string;
@@ -9,5 +10,10 @@ interface SearchRouteParam {
 // eslint-disable-next-line import/no-default-export
 export default function SearchRoute() {
   const { postalCode } = useParams<SearchRouteParam>();
-  return <PharmacyList postalCode={postalCode} />;
+  return (
+    <>
+      <PharmacyList postalCode={postalCode} />
+      <Footer postalCode={postalCode} />
+    </>
+  );
 }


### PR DESCRIPTION
When the user has searched for a postal code, we can update the text in the footer to be contextual based on that code. This change introduces that behaviour in a couple of steps:

1. Extract a `Footer` component out of the `AppFrame` and render it within relevant routes (so that it can be passed appropriate values)
2. Based on the postalCode value, render the appropriate link and text
3. Ensure we support the edge case of Nunavut and Northwest Territories which share a postal district