### PR TITLE
173 don't redirect to home page on language switch

### DIFF
--- a/src/AppFrame.tsx
+++ b/src/AppFrame.tsx
@@ -118,7 +118,6 @@ function getLanguageBarItemProps(): ItemProps[] {
       i18next.language === language.langCode ||
       i18next.language?.substring(0, 2) === language.langCode;
     return {
-      url: "/",
       label: language.label,
       onClick: () => {
         i18next


### PR DESCRIPTION
By removing `url` from the return of `getLanguageBarItemProps`, the user is not redirected to the home page when they select another language ( as per #173 ). To test, navigate to any page other than the home page and select another language.