### PR TITLE
Use the callback format for state updates that toggle values

### DIFF
--- a/src/components/PopUpForm/PopUpForm.tsx
+++ b/src/components/PopUpForm/PopUpForm.tsx
@@ -301,7 +301,7 @@ export function PopUpForm() {
     ? "At least one dose must be checked"
     : undefined;
   const activator = (
-    <Button onClick={() => setIsPopOverActive(!isPopOverActive)} disclosure>
+    <Button onClick={() => setIsPopOverActive((active) => !active)} disclosure>
       {vaccineTypeString}
     </Button>
   );
@@ -406,7 +406,7 @@ export function PopUpForm() {
                     <Popover
                       active={isPopOverActive}
                       activator={activator}
-                      onClose={() => setIsPopOverActive(!isPopOverActive)}
+                      onClose={() => setIsPopOverActive((active) => !active)}
                     >
                       <ActionList
                         items={[
@@ -454,33 +454,29 @@ export function PopUpForm() {
                   <Checkbox
                     label="Walk-Ins"
                     checked={isWalkInChecked}
-                    onChange={() => {
-                      setIsWalkInChecked(!isWalkInChecked);
-                    }}
+                    onChange={() => setIsWalkInChecked((checked) => !checked)}
                     error={invalidBookingMessage}
                   />
                   <Checkbox
                     label="Email"
                     checked={isEmailChecked}
-                    onChange={() => {
-                      setIsEmailChecked(!isEmailChecked);
-                    }}
+                    onChange={() => setIsEmailChecked((checked) => !checked)}
                     error={invalidBookingMessage}
                   />
                   <Checkbox
                     label="Call Ahead"
                     checked={isCallAheadChecked}
-                    onChange={() => {
-                      setIsCallAheadChecked(!isCallAheadChecked);
-                    }}
+                    onChange={() =>
+                      setIsCallAheadChecked((checked) => !checked)
+                    }
                     error={invalidBookingMessage}
                   />
                   <Checkbox
                     label="Visit Website"
                     checked={isVisitWebsiteChecked}
-                    onChange={() => {
-                      setIsVisitWebsiteChecked(!isVisitWebsiteChecked);
-                    }}
+                    onChange={() =>
+                      setIsVisitWebsiteChecked((checked) => !checked)
+                    }
                     error={invalidBookingMessage}
                   />
                 </Stack>
@@ -489,17 +485,13 @@ export function PopUpForm() {
                   <Checkbox
                     label="1st Dose"
                     checked={isFirstDose}
-                    onChange={() => {
-                      setIsFirstDose(!isFirstDose);
-                    }}
+                    onChange={() => setIsFirstDose((checked) => !checked)}
                     error={invalidDoseMessage}
                   />
                   <Checkbox
                     label="2nd Dose"
                     checked={isSecondDose}
-                    onChange={() => {
-                      setIsSecondDose(!isSecondDose);
-                    }}
+                    onChange={() => setIsSecondDose((checked) => !checked)}
                     error={invalidDoseMessage}
                   />
                 </Stack>

--- a/src/containers/ExternalKeyInput/ExternalKeyInput.tsx
+++ b/src/containers/ExternalKeyInput/ExternalKeyInput.tsx
@@ -102,7 +102,7 @@ export function ExternalKeyInput() {
     : undefined;
 
   const activator = (
-    <Button onClick={() => setIsPopOverActive(!isPopOverActive)} disclosure>
+    <Button onClick={() => setIsPopOverActive((active) => !active)} disclosure>
       {organizationName}
     </Button>
   );
@@ -192,7 +192,7 @@ export function ExternalKeyInput() {
                     <Popover
                       active={isPopOverActive}
                       activator={activator}
-                      onClose={() => setIsPopOverActive(!isPopOverActive)}
+                      onClose={() => setIsPopOverActive((active) => !active)}
                     >
                       <ActionList items={organizationListMarkup()} />
                     </Popover>

--- a/src/containers/RapidAppointment/RapidAppointment.tsx
+++ b/src/containers/RapidAppointment/RapidAppointment.tsx
@@ -650,30 +650,26 @@ export function RapidAppointment() {
                   <Checkbox
                     label="Moderna"
                     checked={isModernaChecked}
-                    onChange={() => {
-                      setIsModernaChecked(!isModernaChecked);
-                    }}
+                    onChange={() => setIsModernaChecked((checked) => !checked)}
                   />
                   <Checkbox
                     label="Pfizer"
                     checked={isPfizerChecked}
-                    onChange={() => {
-                      setIsPfizerChecked(!isPfizerChecked);
-                    }}
+                    onChange={() => setIsPfizerChecked((checked) => !checked)}
                   />
                   <Checkbox
                     label="AstraZeneca"
                     checked={isAstraZenecaChecked}
-                    onChange={() => {
-                      setIsAstraZenecaChecked(!isAstraZenecaChecked);
-                    }}
+                    onChange={() =>
+                      setIsAstraZenecaChecked((checked) => !checked)
+                    }
                   />
                   <Checkbox
                     label="Not Sure"
                     checked={isUnknownVaccineChecked}
-                    onChange={() => {
-                      setIsUnknownVaccineChecked(!isUnknownVaccineChecked);
-                    }}
+                    onChange={() =>
+                      setIsUnknownVaccineChecked((checked) => !checked)
+                    }
                   />
                 </Stack>
                 <Stack vertical>
@@ -681,33 +677,29 @@ export function RapidAppointment() {
                   <Checkbox
                     label="Walk-Ins"
                     checked={isWalkInChecked}
-                    onChange={() => {
-                      setIsWalkInChecked(!isWalkInChecked);
-                    }}
+                    onChange={() => setIsWalkInChecked((checked) => !checked)}
                     error={invalidBookingMessage}
                   />
                   <Checkbox
                     label="Email"
                     checked={isEmailChecked}
-                    onChange={() => {
-                      setIsEmailChecked(!isEmailChecked);
-                    }}
+                    onChange={() => setIsEmailChecked((checked) => !checked)}
                     error={invalidBookingMessage}
                   />
                   <Checkbox
                     label="Call Ahead"
                     checked={isCallAheadChecked}
-                    onChange={() => {
-                      setIsCallAheadChecked(!isCallAheadChecked);
-                    }}
+                    onChange={() =>
+                      setIsCallAheadChecked((checked) => !checked)
+                    }
                     error={invalidBookingMessage}
                   />
                   <Checkbox
                     label="Visit Website"
                     checked={isVisitWebsiteChecked}
-                    onChange={() => {
-                      setIsVisitWebsiteChecked(!isVisitWebsiteChecked);
-                    }}
+                    onChange={() =>
+                      setIsVisitWebsiteChecked((checked) => !checked)
+                    }
                     error={invalidBookingMessage}
                   />
                 </Stack>
@@ -718,16 +710,16 @@ export function RapidAppointment() {
                   <Checkbox
                     label="Cancellations"
                     checked={isCancellationsChecked}
-                    onChange={() => {
-                      setIsCancellationsChecked(!isCancellationsChecked);
-                    }}
+                    onChange={() =>
+                      setIsCancellationsChecked((checked) => !checked)
+                    }
                   />
                   <Checkbox
                     label="Expiring Doses"
                     checked={isExpiringDosesChecked}
-                    onChange={() => {
-                      setIsExpiringDosesChecked(!isExpiringDosesChecked);
-                    }}
+                    onChange={() =>
+                      setIsExpiringDosesChecked((checked) => !checked)
+                    }
                   />
                 </Stack>
                 <Stack vertical>
@@ -735,25 +727,19 @@ export function RapidAppointment() {
                   <Checkbox
                     label="1st Dose"
                     checked={isFirstDose}
-                    onChange={() => {
-                      setIsFirstDose(!isFirstDose);
-                    }}
+                    onChange={() => setIsFirstDose((checked) => !checked)}
                     error={invalidDoseMessage}
                   />
                   <Checkbox
                     label="2nd Dose"
                     checked={isSecondDose}
-                    onChange={() => {
-                      setIsSecondDose(!isSecondDose);
-                    }}
+                    onChange={() => setIsSecondDose((checked) => !checked)}
                     error={invalidDoseMessage}
                   />
                   <Checkbox
                     label="3rd Dose"
                     checked={isThirdDose}
-                    onChange={() => {
-                      setIsThirdDose(!isThirdDose);
-                    }}
+                    onChange={() => setIsThirdDose((checked) => !checked)}
                     error={invalidDoseMessage}
                   />
                 </Stack>
@@ -762,17 +748,13 @@ export function RapidAppointment() {
                   <Checkbox
                     label="5-11 Year Old"
                     checked={isChildrenDoses}
-                    onChange={() => {
-                      setIsChildrenDoses(!isChildrenDoses);
-                    }}
+                    onChange={() => setIsChildrenDoses((checked) => !checked)}
                     error={invalidAgeMessage}
                   />
                   <Checkbox
                     label="12+ Year Old"
                     checked={isAdultDoses}
-                    onChange={() => {
-                      setIsAdultDoses(!isAdultDoses);
-                    }}
+                    onChange={() => setIsAdultDoses((checked) => !checked)}
                     error={invalidAgeMessage}
                   />
                 </Stack>


### PR DESCRIPTION
Fixes #187

When toggling a boolean value, we'd prefer to use the callback format of `setState`. This ensures that any actions that get dispatched will operate on the true value of the state, and not what happens to currently be set in the scope of the component.

Ticket asks for this to be done for the rapid appointment form, but updated the remaining uses as well for consistency.